### PR TITLE
return workflow result on submit

### DIFF
--- a/argo/workflows/dsl/_workflow.py
+++ b/argo/workflows/dsl/_workflow.py
@@ -386,10 +386,10 @@ class Workflow(metaclass=WorkflowMeta):
         namespace: str,
         *,
         parameters: Optional[Dict[str, str]] = None,
-    ) -> str:
+    ) -> V1alpha1Workflow:
         """Submit an Argo Workflow to a given namespace.
 
-        :returns: str, Workflow name
+        :returns: V1alpha1Workflow, submitted Workflow
         """
         parameters = parameters or {}
 
@@ -430,7 +430,7 @@ class Workflow(metaclass=WorkflowMeta):
             namespace, body
         )
 
-        # return the computed Workflow ID
+        # return the computed Workflow
         return created
 
     def to_file(self, fp: Union[Path, str], fmt="yaml", **kwargs):

--- a/argo/workflows/dsl/_workflow.py
+++ b/argo/workflows/dsl/_workflow.py
@@ -431,7 +431,7 @@ class Workflow(metaclass=WorkflowMeta):
         )
 
         # return the computed Workflow ID
-        return self.name
+        return created
 
     def to_file(self, fp: Union[Path, str], fmt="yaml", **kwargs):
         """Dumps the Workflow to a file."""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -3,7 +3,7 @@ import pytest
 import requests
 
 from argo.workflows.client import V1alpha1Api
-from argo.workflows.client.models import V1alpha1Arguments, V1alpha1Parameter
+from argo.workflows.client.models import V1alpha1Workflow, V1alpha1Arguments, V1alpha1Parameter
 
 from argo.workflows.dsl import Workflow
 
@@ -87,9 +87,10 @@ class TestWorkflow(TestCase):
         wf.spec.arguments = V1alpha1Arguments(
             parameters=[V1alpha1Parameter(name="param")]
         )
-        workflow_name: str = wf.submit(
+        workflow_result: str = wf.submit(
             client=api, namespace="test", parameters={"param": "test"}
         )
 
-        assert isinstance(workflow_name, str)
-        assert workflow_name == "test"
+        assert isinstance(workflow_result, V1alpha1Workflow)
+        assert isinstance(workflow_result.metadata.name, str)
+        assert workflow_result.metadata.name == "test"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -93,4 +93,7 @@ class TestWorkflow(TestCase):
 
         assert isinstance(workflow_result, V1alpha1Workflow)
         assert isinstance(workflow_result.metadata.name, str)
+        assert len(workflow_result.spec.arguments.parameters) == 1
+        assert workflow_result.spec.arguments.parameters[0].name == 'param'
+        assert workflow_result.spec.arguments.parameters[0].value == 'test'
         assert workflow_result.metadata.name == "test"


### PR DESCRIPTION
Just to be consistent with `argo-client-python` returning `result --> V1alpha1Workflow` on workflow `submit()`

if approved this needs to be merged first before #15 